### PR TITLE
ifconfig patterns backward compatibility added

### DIFF
--- a/unix/ej_process.c
+++ b/unix/ej_process.c
@@ -1371,4 +1371,3 @@ ejudge_timed_fdgets(
 fail:
   return -1;
 }
-`

--- a/unix/ej_process.c
+++ b/unix/ej_process.c
@@ -1031,8 +1031,10 @@ ejudge_get_host_names(void)
   unsigned char buf[1024], *s, nbuf[1024];
   struct utsname uname_buf;
 
-  static const unsigned char pat1[] = "inet ";
-  static const unsigned char pat2[] = "inet6 ";
+  static const unsigned char pat1[] = "inet addr:";
+  static const unsigned char pat2[] = "inet6 addr:";
+  static const unsigned char pat3[] = "inet";
+  static const unsigned char pat4[] = "inet6";
 
   XCALLOC(names, names_z);
   if (!(f = popen("/sbin/ifconfig", "r"))) goto fail;
@@ -1050,6 +1052,10 @@ ejudge_get_host_names(void)
       sscanf(s + sizeof(pat1) - 1, "%s", nbuf);
     } else if ((s = strstr(buf, pat2))) {
       sscanf(s + sizeof(pat2) - 1, "%s", nbuf);
+    } else if ((s = strstr(buf, pat3))) {
+      sscanf(s + sizeof(pat3) - 1, "%s", nbuf);
+    } else if ((s = strstr(buf, pat4))) {
+      sscanf(s + sizeof(pat4) - 1, "%s", nbuf);
     }
 
     if (nbuf[0]) {
@@ -1365,3 +1371,4 @@ ejudge_timed_fdgets(
 fail:
   return -1;
 }
+`


### PR DESCRIPTION
In some Linux distributives (like Debian Jessie) /sbin/ifconfig still has output format "inet addr:". 
So, it'll be good to have support for both patterns' variants.