### PR TITLE
fix bug in group filter at user_browse_page

### DIFF
--- a/csp/super-server/user_browse_page.csp
+++ b/csp/super-server/user_browse_page.csp
@@ -128,7 +128,7 @@ jQuery(document).ready(function()
 {
     jQuery("#usertable").jqGrid({
         url: self_url,
-        postData: { 'SID' : SID, 'contest_id' : contest_id, 'action' : user_browse_data }, 
+        postData: { 'SID' : SID, 'contest_id' : contest_id, 'group_id' : group_id, 'action' : user_browse_data }, 
         datatype: 'json',
         colNames: [ 'NN', 'UId', 'User Login', 'E-mail', 'Name', 'Status', 'Flags' ],
         colModel: [


### PR DESCRIPTION
"Jump to group:" feature in browsing of users from serve-control was copletely broken. 

Partially fixed that issue (filtering now works, but it is still impossible to change filter value unless you reopen user browsing page from serve-control main page or user_groups page ).