### PR TITLE
fixed unpriv_standings for OLYMPIAD mode

### DIFF
--- a/csp/contests/unpriv_standings_page.csp
+++ b/csp/contests/unpriv_standings_page.csp
@@ -80,7 +80,8 @@
   } else if (global->score_system == SCORE_OLYMPIAD && cs->accepting_mode) {
 %><p><s:_>Information is not available.</s:_></p><%
   } else if (global->score_system == SCORE_OLYMPIAD) {
-%><p><s:_>Information is not available.</s:_></p><%
+    do_write_kirov_standings(cs, cnts, out_f, 0, 1, 1, phr->user_id, 0, 0, 0, 0, 1, cur_time,
+                             0, NULL, 1 /* user_mode */);
   } else if (global->score_system == SCORE_KIROV) {
     do_write_kirov_standings(cs, cnts, out_f, 0, 1, 1, phr->user_id, 0, 0, 0, 0, 1, cur_time,
                              0, NULL, 1 /* user_mode */);


### PR DESCRIPTION
Commit  [98292b5](https://github.com/blackav/ejudge/commit/98292b5ee8fc65e47ac9bb7dc3d6896bbc11caea) broke standings showing after switching to "judging mode" for OLYMPIAD contests.