### PR TITLE
fixed viewing of future runs in unprivileged mode during virtual contest

### DIFF
--- a/html.c
+++ b/html.c
@@ -1040,6 +1040,8 @@ do_write_kirov_standings(
   time_t start_time;
   time_t stop_time;
   time_t cur_duration;
+  time_t tdur = 0;
+  time_t team_start_time;
   time_t run_time;
   time_t contest_dur;
 
@@ -1369,7 +1371,12 @@ do_write_kirov_standings(
      */
     
     run_time = pe->time;
-    if (!client_flag || user_id > 0) {
+    if (global->is_virtual && !state->upsolving_mode) {
+      // filter future runs in unprivileged mode (not upsolving)		
+      team_start_time = run_get_virtual_start_time(state->runlog_state, pe->user_id);
+      tdur = run_time - team_start_time;
+      if (user_id > 0 && tdur > cur_duration) continue;		
+    } else if (!client_flag || user_id > 0) {
     // ignore future runs when not in privileged mode
       if (run_time < start_time) run_time = start_time;
       if (stop_time && run_time > stop_time) run_time = stop_time;


### PR DESCRIPTION
Исправляет ошибку компиляции в [34b2ab1](https://github.com/blackav/ejudge/commit/34b2ab1005d183132972f68f33069efea65ba833)