### PR TITLE
Fix for userlist_clnt/get_xml_by_text.c

### DIFF
--- a/userlist_clnt/get_xml_by_text.c
+++ b/userlist_clnt/get_xml_by_text.c
@@ -33,7 +33,8 @@ userlist_clnt_get_xml_by_text(
   if (!request_text) request_text = "";
   request_len = strlen(request_text);
   out_size = sizeof(*out) + request_len;
-  XALLOCAZ(out, 1);
+  out = (typeof(out)) alloca(out_size);
+  memset(out, 0, out_size);
   out->request_id = cmd;
   out->info_len = request_len;
   memcpy(out->data, request_text, request_len + 1);


### PR DESCRIPTION
Исправил баг в userlist_clnt/get_xml_by_text.c:
для переменной out выделялось недостаточно памяти.
Баг был незаметен для коротких запросов, потому что они помещались в предыдущие переменные на стеке. Однако для длинных запросов (например, если в контесте есть несколько групп пользователей) перезаписывался адрес возвращаемого значения reply_text, что приводило к тому, что в *reply_text ничего не записывалось и контест загрузить было невозможно.