### PR TITLE
Remove white background color for operators

### DIFF
--- a/style/prism.css
+++ b/style/prism.css
@@ -105,7 +105,6 @@ pre[class*="language-"] {
 .language-css .token.string,
 .style .token.string {
 	color: #a67f59;
-	background: hsla(0, 0%, 100%, .5);
 }
 
 .token.atrule,


### PR DESCRIPTION
I see extra-white background of operators. Is it a bug or a feature?

The current state:
![image](https://user-images.githubusercontent.com/20105593/52301210-fa25e280-299a-11e9-9fa3-00e9a8b656a4.png)

The current state (high-contrasted):
![caos](https://user-images.githubusercontent.com/20105593/52301486-8fc17200-299b-11e9-8eaf-bd6fc0758d4f.PNG)

The state after this Pull Request:
![image](https://user-images.githubusercontent.com/20105593/52301546-b1225e00-299b-11e9-8b52-b7776c148f10.png)