### PR TITLE
html_problem_selection(): respect hide_variant

### DIFF
--- a/lib/new_server_html.c
+++ b/lib/new_server_html.c
@@ -10990,7 +10990,7 @@ html_problem_selection(serve_state_t cs,
         snprintf(penalty_str, sizeof(penalty_str), " [%d]", user_penalty);
     }
 
-    if (prob->variant_num > 0) {
+    if (prob->variant_num > 0 && prob->hide_variant <= 0) {
       if ((variant = find_variant(cs, phr->user_id, i, 0)) <= 0) continue;
       snprintf(problem_str, sizeof(problem_str),
                "%s-%d", prob->short_name, variant);


### PR DESCRIPTION
This effectively hides variant number in the clar request
submission interface if hide_variant is set. (See the use of
the changed function in unpriv_main_clar_submit.csp.)

I think, html_problem_selection_2() should be changed in the
same way, but currently don't have a setup to test that.