### PR TITLE
fix null pointer dereference in ej-compile

### DIFF
--- a/lib/prepare.c
+++ b/lib/prepare.c
@@ -3482,7 +3482,7 @@ set_defaults(
     }
 
     if (mode == PREPARE_COMPILE) {
-      if (!lang->cmd && !lang->cmd[0]) {
+      if (!lang->cmd || !lang->cmd[0]) {
         err("language.%d.cmd must be set", i);
         return -1;
       }


### PR DESCRIPTION
Could be caught with e.g. gcc -O -Wnull-dereference.