### PR TITLE
Guard against NULL plugin config.

### DIFF
--- a/lib/common_plugin.c
+++ b/lib/common_plugin.c
@@ -127,6 +127,10 @@ plugin_load_external(
   }
 
   pcfg = ejudge_cfg_get_plugin_config(config, type, name);
+  if (!pcfg) {
+    err("%s: plugin configuration not found for %s, %s", fname, type, name);
+    return NULL;
+  }
   if (!(data = common_iface->init())) {
     err("%s: init failed for %s, %s", fname, type, name);
     return NULL;


### PR DESCRIPTION
Prevent ej-contests crashing on a bad plugin configuration.