### PR TITLE
fix SIGPIPE handling in tasks

### DIFF
--- a/unix/reuse_exec.c
+++ b/unix/reuse_exec.c
@@ -2271,6 +2271,9 @@ task_Start(tTask *tsk)
 
     if (tsk->ignore_sigpipe) {
       signal(SIGPIPE, SIG_IGN);
+    } else {
+      // SIGPIPE may have been ignored in parent process (e.g. ejudge-super-run)
+      signal(SIGPIPE, SIG_DFL);
     }
 
     if (tsk->enable_suid_exec) {


### PR DESCRIPTION
ejudge-super-run игнорирует SIGPIPE, из-за этого в запускаемых посылках SIGPIPE игнорируется по умолчанию.

```c
#include <assert.h>
#include <signal.h>

int main() {
    assert(signal(SIGPIPE, SIG_DFL) == SIG_IGN);
}
```

При запуске вручную такой код ожидаемо падает, но в ejudge такой assert проходит (проверено на версиях ejudge 3.8.0 и 3.9.1)

Другой пример:
```c
#include <signal.h>
#include <unistd.h>

int main() {
    // "Забыли" проигнорировать сигнал
    // signal(SIGPIPE, SIG_IGN);
    int fds[2];
    pipe(fds);
    close(fds[0]);
    write(fds[1], "test", 4);
    // Процесс должен получить сигнал и упасть, но при запуске в ejudge write просто возвращает -1
}
```