### PR TITLE
Update copyright.c: http://www.ejudge.ru returns 404

### DIFF
--- a/lib/copyright.c
+++ b/lib/copyright.c
@@ -37,7 +37,7 @@ make_copyright(unsigned char *buf, size_t size)
              "<p class=\"ejudge_copyright\">This program is copyright &copy; %s Alexander Chernov.</p>\n"
              "<p class=\"ejudge_copyright\">"
              "This program is free software; you can redistribute it and/or modify it under the terms of the <a href=\"http://www.gnu.org/licenses/gpl.html\">GNU General Public License</a> as published by the <a href=\"http://www.fsf.org\">Free Software Foundation</a>; either version 2 of the License, or (at your option) any later version.</p>\n"),
-           "http://www.ejudge.ru",
+           "https://ejudge.ru",
            compile_version, compile_date, "2000-2022");
 }
 
@@ -65,6 +65,6 @@ write_copyright_short(FILE *out_f)
   fprintf(out_f,
           "<p class=\"ejudge_copyright\"><a href=\"%s\">ejudge %s (%s)</a>.</p>\n"
           "<p class=\"ejudge_copyright\">Copyright &copy; %s Alexander Chernov.</p>\n",
-          "http://www.ejudge.ru",
+          "https://ejudge.ru",
           compile_version, compile_date, "2000-2022");
 }


### PR DESCRIPTION
Update url in copyright.c: replace http://www.ejudge.ru with https://ejudge.ru. Old website in unavailable now.