### PR TITLE
Fix fd leak in tasks

### DIFF
--- a/unix/reuse_exec.c
+++ b/unix/reuse_exec.c
@@ -23,6 +23,7 @@
 #include "ejudge/osdeps.h"
 #include "ejudge/exec.h"
 #include "ejudge/process_stats.h"
+#include "ejudge/random.h"
 
 #include <sys/types.h>
 #include <sys/wait.h>
@@ -2275,6 +2276,8 @@ task_Start(tTask *tsk)
       // SIGPIPE may have been ignored in parent process (e.g. ejudge-super-run)
       signal(SIGPIPE, SIG_DFL);
     }
+    // prevent fd leak (random can be used in scan_dir from unix/fileutl.c)
+    random_cleanup();
 
     if (tsk->enable_suid_exec) {
       invoke_execv_helper(tsk, tsk->path, tsk->args.v);


### PR DESCRIPTION
ej-super-run открывает `/dev/urandom`, если в очереди посылок одновременно находятся посылки с разными приоритетами (например, новая посылка и посылка, отправленная на перетестирование).
https://github.com/blackav/ejudge/blob/291c1d020e014a79ce9ce3f877c3507f37bd2d5d/bin/ej-super-run.c#L581
https://github.com/blackav/ejudge/blob/291c1d020e014a79ce9ce3f877c3507f37bd2d5d/unix/fileutl.c#L305

`random_cleanup` нигде не вызывается,  дескриптор утекает в запущенные решения. Из-за этого может некорректно работать ограничение на количество открытых дескрипторов 