### PR TITLE
Add missing short statuses

### DIFF
--- a/lib/runlog_static.c
+++ b/lib/runlog_static.c
@@ -481,6 +481,13 @@ static const unsigned char * const status_short_str[] =
   [RUN_SUMMONED] = "SM",
   [RUN_REJECTED] = "RJ",
   [RUN_SKIPPED] = "SK",
+  [RUN_RUNNING ] = "RU",
+  [RUN_COMPILED] = "CD",
+  [RUN_COMPILING] = "CG",
+  [RUN_AVAILABLE] = "AV",
+  [RUN_EMPTY] = "EM",
+  [RUN_VIRTUAL_START] = "VS",
+  [RUN_VIRTUAL_STOP] = "VT",
 };
 
 const unsigned char *


### PR DESCRIPTION
Эти статусы описаны в формате фильтров (style/filter_expr.html), но почему-то их не было в массиве.
Из-за этого в методах API `list-runs-json` и `run-status-json` для некоторых статусов неправильно заполнялось поле "status_str".
Например, у посылок со статусом 22 (EMPTY, удалённые посылки) оно было равно "22", а не "EM".