### PR TITLE
fix priv_download_source

### DIFF
--- a/lib/new_server_html.c
+++ b/lib/new_server_html.c
@@ -6009,6 +6009,8 @@ priv_download_source(
     }
   }
 
+  phr->json_reply = 0;
+
   fprintf(fout, "Content-type: %s\n", content_type);
   if (!no_disp) {
     fprintf(fout, "Content-Disposition: attachment; filename=\"%06d%s\"\n",


### PR DESCRIPTION
`curl "http://localhost/cgi-bin/new-judge?action=download-run&json=1&SID=...&EJSID=...&run_id=123"`

Тело ответа на запрос с SID и EJSID, полученными через обычный аккаунт (run_id, принадлежит пользователю, запрос обрабатывается в `unpriv_download_run`):
```
int main() {
}
```

Если SID и EJSID получены через аккаунт судьи (запрос обрабатывается в `priv_download_source`):
```
Content-type: text/plain
Content-Disposition: attachment; filename="000266.S"

int main() {
}
```