### PR TITLE
Add EJUDGE_MAX_SCORE for scoring_checker

### DIFF
--- a/lib/run_common.c
+++ b/lib/run_common.c
@@ -2431,12 +2431,37 @@ invoke_checker(
   if (srpp->checker_max_rss_size > 0) {
     task_SetRSSSize(tsk, srpp->checker_max_rss_size);
   }
+	
+  switch (srgp->scoring_system_val) {
+  case SCORE_KIROV:
+  case SCORE_OLYMPIAD:
+    test_max_score = -1;
+    if (test_score_val && cur_test > 0 && cur_test < test_score_count) {
+      test_max_score = test_score_val[cur_test];
+    }
+    if (test_max_score < 0) {
+      test_max_score = srpp->test_score;
+    }
+    if (test_max_score < 0) test_max_score = 0;
+    break;
+  case SCORE_MOSCOW:
+    test_max_score = srpp->full_score - 1;
+    break;
+  case SCORE_ACM:
+    test_max_score = 0;
+    break;
+  default:
+    abort();
+  }
   setup_environment(tsk, srpp->checker_env, env_u, env_v, 1);
   if (srpp->scoring_checker > 0) {
     task_SetEnv(tsk, "EJUDGE_SCORING_CHECKER", "1");
     if (srpp->enable_checker_token > 0) {
       task_SetEnv(tsk, "EJUDGE_CHECKER_TOKEN", "1");
     }
+    unsigned char buf[64];
+    snprintf(buf, sizeof(buf), "%d", test_max_score);
+    task_SetEnv(tsk, "EJUDGE_MAX_SCORE", buf);
   }
   task_SetEnv(tsk, "EJUDGE", "1");
   if (srgp->checker_locale && srgp->checker_locale[0]) {
@@ -2518,28 +2543,7 @@ invoke_checker(
     }
     goto cleanup;
   }
-
-  switch (srgp->scoring_system_val) {
-  case SCORE_KIROV:
-  case SCORE_OLYMPIAD:
-    test_max_score = -1;
-    if (test_score_val && cur_test > 0 && cur_test < test_score_count) {
-      test_max_score = test_score_val[cur_test];
-    }
-    if (test_max_score < 0) {
-      test_max_score = srpp->test_score;
-    }
-    if (test_max_score < 0) test_max_score = 0;
-    break;
-  case SCORE_MOSCOW:
-    test_max_score = srpp->full_score - 1;
-    break;
-  case SCORE_ACM:
-    test_max_score = 0;
-    break;
-  default:
-    abort();
-  }
+	
   if (srpp->scoring_checker > 0) {
     int user_score = -1;
     int user_status = -1;


### PR DESCRIPTION
Добавляет переменную окружения EJUDGE_MAX_SCORE для проверяющей программы выставляемую только при включенном score_checker флаге и равную максимальному количеству баллов за этот тест.

Мотивация: А как частичные баллы ставить если максимума не знаем?(