### PR TITLE
Переменные окружения для компиляторов: EJUDGE_ADD_FLAGS, EJUDGE_ADD_LIBS

### DIFF
--- a/scripts/clang++-32.in
+++ b/scripts/clang++-32.in
@@ -30,6 +30,9 @@ fi
 [ x"${EJUDGE_FLAGS}" = x ] && EJUDGE_FLAGS="-Wall -O2"
 [ x"${EJUDGE_LIBS}" = x ] && EJUDGE_LIBS="-lm"
 
+[ x"${EJUDGE_ADD_FLAGS}" != x ] && EJUDGE_FLAGS="${EJUDGE_FLAGS} ${EJUDGE_ADD_FLAGS}"
+[ x"${EJUDGE_ADD_LIBS}" != x ] && EJUDGE_LIBS="${EJUDGE_LIBS} ${EJUDGE_ADD_LIBS}"
+
 unset LANG
 unset LC_ALL
 unset LC_MESSAGES

--- a/scripts/clang++.in
+++ b/scripts/clang++.in
@@ -30,6 +30,9 @@ fi
 [ x"${EJUDGE_FLAGS}" = x ] && EJUDGE_FLAGS="-Wall -O2"
 [ x"${EJUDGE_LIBS}" = x ] && EJUDGE_LIBS="-lm"
 
+[ x"${EJUDGE_ADD_FLAGS}" != x ] && EJUDGE_FLAGS="${EJUDGE_FLAGS} ${EJUDGE_ADD_FLAGS}"
+[ x"${EJUDGE_ADD_LIBS}" != x ] && EJUDGE_LIBS="${EJUDGE_LIBS} ${EJUDGE_ADD_LIBS}"
+
 unset LANG
 unset LC_ALL
 unset LC_MESSAGES

--- a/scripts/clang-32.in
+++ b/scripts/clang-32.in
@@ -30,6 +30,9 @@ fi
 [ x"${EJUDGE_FLAGS}" = x ] && EJUDGE_FLAGS="-Wall -O2 -std=gnu99"
 [ x"${EJUDGE_LIBS}" = x ] && EJUDGE_LIBS="-lm"
 
+[ x"${EJUDGE_ADD_FLAGS}" != x ] && EJUDGE_FLAGS="${EJUDGE_FLAGS} ${EJUDGE_ADD_FLAGS}"
+[ x"${EJUDGE_ADD_LIBS}" != x ] && EJUDGE_LIBS="${EJUDGE_LIBS} ${EJUDGE_ADD_LIBS}"
+
 unset LANG
 unset LC_ALL
 unset LC_MESSAGES

--- a/scripts/clang.in
+++ b/scripts/clang.in
@@ -30,6 +30,9 @@ fi
 [ x"${EJUDGE_FLAGS}" = x ] && EJUDGE_FLAGS="-Wall -O2 -std=gnu99"
 [ x"${EJUDGE_LIBS}" = x ] && EJUDGE_LIBS="-lm"
 
+[ x"${EJUDGE_ADD_FLAGS}" != x ] && EJUDGE_FLAGS="${EJUDGE_FLAGS} ${EJUDGE_ADD_FLAGS}"
+[ x"${EJUDGE_ADD_LIBS}" != x ] && EJUDGE_LIBS="${EJUDGE_LIBS} ${EJUDGE_ADD_LIBS}"
+
 unset LANG
 unset LC_ALL
 unset LC_MESSAGES

--- a/scripts/dcc.in
+++ b/scripts/dcc.in
@@ -29,6 +29,8 @@ then
     export KYLIXDIR
 fi
 
+[ x"${EJUDGE_ADD_FLAGS}" != x ] && EJUDGE_FLAGS="${EJUDGE_FLAGS} ${EJUDGE_ADD_FLAGS}"
+
 unset LANG
 unset LC_ALL
 unset LC_MESSAGES

--- a/scripts/dotnet-cs.in
+++ b/scripts/dotnet-cs.in
@@ -31,6 +31,8 @@ fi
 
 #[[ "${EJUDGE_FLAGS}" = "" ]] && EJUDGE_FLAGS="-optimize+"
 
+[ x"${EJUDGE_ADD_FLAGS}" != x ] && EJUDGE_FLAGS="${EJUDGE_FLAGS} ${EJUDGE_ADD_FLAGS}"
+
 unset LANG
 unset LC_ALL
 unset LC_MESSAGES

--- a/scripts/dotnet-vb.in
+++ b/scripts/dotnet-vb.in
@@ -31,6 +31,8 @@ fi
 
 #[[ "${EJUDGE_FLAGS}" = "" ]] && EJUDGE_FLAGS="-optimize+"
 
+[ x"${EJUDGE_ADD_FLAGS}" != x ] && EJUDGE_FLAGS="${EJUDGE_FLAGS} ${EJUDGE_ADD_FLAGS}"
+
 unset LANG
 unset LC_ALL
 unset LC_MESSAGES

--- a/scripts/fbc-32.in
+++ b/scripts/fbc-32.in
@@ -27,6 +27,8 @@ then
     PATH="${FBCDIR}:${PATH}"
 fi
 
+[ x"${EJUDGE_ADD_FLAGS}" != x ] && EJUDGE_FLAGS="${EJUDGE_FLAGS} ${EJUDGE_ADD_FLAGS}"
+
 unset LANG
 unset LC_ALL
 unset LC_MESSAGES

--- a/scripts/fbc.in
+++ b/scripts/fbc.in
@@ -27,6 +27,8 @@ then
     PATH="${FBCDIR}:${PATH}"
 fi
 
+[ x"${EJUDGE_ADD_FLAGS}" != x ] && EJUDGE_FLAGS="${EJUDGE_FLAGS} ${EJUDGE_ADD_FLAGS}"
+
 unset LANG
 unset LC_ALL
 unset LC_MESSAGES

--- a/scripts/fpc-32.in
+++ b/scripts/fpc-32.in
@@ -27,6 +27,8 @@ then
     PATH="${FPCDIR}:${PATH}"
 fi
 
+[ x"${EJUDGE_ADD_FLAGS}" != x ] && EJUDGE_FLAGS="${EJUDGE_FLAGS} ${EJUDGE_ADD_FLAGS}"
+
 unset LANG
 unset LC_ALL
 unset LC_MESSAGES

--- a/scripts/fpc.in
+++ b/scripts/fpc.in
@@ -27,6 +27,8 @@ then
     PATH="${FPCDIR}:${PATH}"
 fi
 
+[ x"${EJUDGE_ADD_FLAGS}" != x ] && EJUDGE_FLAGS="${EJUDGE_FLAGS} ${EJUDGE_ADD_FLAGS}"
+
 unset LANG
 unset LC_ALL
 unset LC_MESSAGES

--- a/scripts/g++-32.in
+++ b/scripts/g++-32.in
@@ -30,6 +30,9 @@ fi
 [ x"${EJUDGE_FLAGS}" = x ] && EJUDGE_FLAGS="-Wall -O2"
 [ x"${EJUDGE_LIBS}" = x ] && EJUDGE_LIBS="-lm"
 
+[ x"${EJUDGE_ADD_FLAGS}" != x ] && EJUDGE_FLAGS="${EJUDGE_FLAGS} ${EJUDGE_ADD_FLAGS}"
+[ x"${EJUDGE_ADD_LIBS}" != x ] && EJUDGE_LIBS="${EJUDGE_LIBS} ${EJUDGE_ADD_LIBS}"
+
 unset LANG
 unset LC_ALL
 unset LC_MESSAGES

--- a/scripts/g++-vg.in
+++ b/scripts/g++-vg.in
@@ -30,6 +30,9 @@ fi
 [ x"${EJUDGE_FLAGS}" = x ] && EJUDGE_FLAGS="-O2 -g"
 [ x"${EJUDGE_LIBS}" = x ] && EJUDGE_LIBS="-lm"
 
+[ x"${EJUDGE_ADD_FLAGS}" != x ] && EJUDGE_FLAGS="${EJUDGE_FLAGS} ${EJUDGE_ADD_FLAGS}"
+[ x"${EJUDGE_ADD_LIBS}" != x ] && EJUDGE_LIBS="${EJUDGE_LIBS} ${EJUDGE_ADD_LIBS}"
+
 unset LANG
 unset LC_ALL
 unset LC_MESSAGES

--- a/scripts/g++.in
+++ b/scripts/g++.in
@@ -29,6 +29,9 @@ fi
 [ x"${EJUDGE_FLAGS}" = x ] && EJUDGE_FLAGS="-Wall -O2 -std=gnu++11"
 #[ x"${EJUDGE_LIBS}" = x ] && EJUDGE_LIBS="-lm"
 
+[ x"${EJUDGE_ADD_FLAGS}" != x ] && EJUDGE_FLAGS="${EJUDGE_FLAGS} ${EJUDGE_ADD_FLAGS}"
+[ x"${EJUDGE_ADD_LIBS}" != x ] && EJUDGE_LIBS="${EJUDGE_LIBS} ${EJUDGE_ADD_LIBS}"
+
 unset LANG
 unset LC_ALL
 unset LC_MESSAGES

--- a/scripts/g77.in
+++ b/scripts/g77.in
@@ -28,6 +28,8 @@ fi
 
 [ x"${EJUDGE_FLAGS}" = x ] && EJUDGE_FLAGS="-O2"
 
+[ x"${EJUDGE_ADD_FLAGS}" != x ] && EJUDGE_FLAGS="${EJUDGE_FLAGS} ${EJUDGE_ADD_FLAGS}"
+
 unset LANG
 unset LC_ALL
 unset LC_MESSAGES

--- a/scripts/gas-32.in
+++ b/scripts/gas-32.in
@@ -29,6 +29,9 @@ fi
 [ x"${EJUDGE_FLAGS}" = x ] && EJUDGE_FLAGS=""
 [ x"${EJUDGE_LIBS}" = x ] && EJUDGE_LIBS="-lm"
 
+[ x"${EJUDGE_ADD_FLAGS}" != x ] && EJUDGE_FLAGS="${EJUDGE_FLAGS} ${EJUDGE_ADD_FLAGS}"
+[ x"${EJUDGE_ADD_LIBS}" != x ] && EJUDGE_LIBS="${EJUDGE_LIBS} ${EJUDGE_ADD_LIBS}"
+
 unset LANG
 unset LC_ALL
 unset LC_MESSAGES

--- a/scripts/gas.in
+++ b/scripts/gas.in
@@ -29,6 +29,9 @@ fi
 [ x"${EJUDGE_FLAGS}" = x ] && EJUDGE_FLAGS=""
 [ x"${EJUDGE_LIBS}" = x ] && EJUDGE_LIBS="-lm"
 
+[ x"${EJUDGE_ADD_FLAGS}" != x ] && EJUDGE_FLAGS="${EJUDGE_FLAGS} ${EJUDGE_ADD_FLAGS}"
+[ x"${EJUDGE_ADD_LIBS}" != x ] && EJUDGE_LIBS="${EJUDGE_LIBS} ${EJUDGE_ADD_LIBS}"
+
 unset LANG
 unset LC_ALL
 unset LC_MESSAGES

--- a/scripts/gcc-32.in
+++ b/scripts/gcc-32.in
@@ -30,6 +30,9 @@ fi
 [ x"${EJUDGE_FLAGS}" = x ] && EJUDGE_FLAGS="-Wall -O2 -std=gnu99"
 [ x"${EJUDGE_LIBS}" = x ] && EJUDGE_LIBS="-lm"
 
+[ x"${EJUDGE_ADD_FLAGS}" != x ] && EJUDGE_FLAGS="${EJUDGE_FLAGS} ${EJUDGE_ADD_FLAGS}"
+[ x"${EJUDGE_ADD_LIBS}" != x ] && EJUDGE_LIBS="${EJUDGE_LIBS} ${EJUDGE_ADD_LIBS}"
+
 unset LANG
 unset LC_ALL
 unset LC_MESSAGES

--- a/scripts/gcc-vg.in
+++ b/scripts/gcc-vg.in
@@ -30,6 +30,9 @@ fi
 [ x"${EJUDGE_FLAGS}" = x ] && EJUDGE_FLAGS="-g -O2 -std=gnu11"
 [ x"${EJUDGE_LIBS}" = x ] && EJUDGE_LIBS="-lm"
 
+[ x"${EJUDGE_ADD_FLAGS}" != x ] && EJUDGE_FLAGS="${EJUDGE_FLAGS} ${EJUDGE_ADD_FLAGS}"
+[ x"${EJUDGE_ADD_LIBS}" != x ] && EJUDGE_LIBS="${EJUDGE_LIBS} ${EJUDGE_ADD_LIBS}"
+
 unset LANG
 unset LC_ALL
 unset LC_MESSAGES

--- a/scripts/gcc.in
+++ b/scripts/gcc.in
@@ -29,6 +29,9 @@ fi
 [ x"${EJUDGE_FLAGS}" = x ] && EJUDGE_FLAGS="-Wall -O2 -std=gnu11"
 [ x"${EJUDGE_LIBS}" = x ] && EJUDGE_LIBS="-lm"
 
+[ x"${EJUDGE_ADD_FLAGS}" != x ] && EJUDGE_FLAGS="${EJUDGE_FLAGS} ${EJUDGE_ADD_FLAGS}"
+[ x"${EJUDGE_ADD_LIBS}" != x ] && EJUDGE_LIBS="${EJUDGE_LIBS} ${EJUDGE_ADD_LIBS}"
+
 unset LANG
 unset LC_ALL
 unset LC_MESSAGES

--- a/scripts/gccgo.in
+++ b/scripts/gccgo.in
@@ -28,6 +28,8 @@ fi
 
 #[ x"${EJUDGE_FLAGS}" = x ] && EJUDGE_FLAGS="-O2"
 
+[ x"${EJUDGE_ADD_FLAGS}" != x ] && EJUDGE_FLAGS="${EJUDGE_FLAGS} ${EJUDGE_ADD_FLAGS}"
+
 unset LANG
 unset LC_ALL
 unset LC_MESSAGES

--- a/scripts/gcj.in
+++ b/scripts/gcj.in
@@ -29,6 +29,8 @@ fi
 
 [ x"${EJUDGE_FLAGS}" = x ] && EJUDGE_FLAGS="-Wall -O2"
 
+[ x"${EJUDGE_ADD_FLAGS}" != x ] && EJUDGE_FLAGS="${EJUDGE_FLAGS} ${EJUDGE_ADD_FLAGS}"
+
 unset LANG
 unset LC_ALL
 unset LC_MESSAGES

--- a/scripts/gfortran.in
+++ b/scripts/gfortran.in
@@ -28,6 +28,8 @@ fi
 
 [ x"${EJUDGE_FLAGS}" = x ] && EJUDGE_FLAGS="-O2"
 
+[ x"${EJUDGE_ADD_FLAGS}" != x ] && EJUDGE_FLAGS="${EJUDGE_FLAGS} ${EJUDGE_ADD_FLAGS}"
+
 unset LANG
 unset LC_ALL
 unset LC_MESSAGES

--- a/scripts/ghc.in
+++ b/scripts/ghc.in
@@ -29,6 +29,8 @@ fi
 
 [ x"${EJUDGE_FLAGS}" = x ] && EJUDGE_FLAGS="-O -H14m"
 
+[ x"${EJUDGE_ADD_FLAGS}" != x ] && EJUDGE_FLAGS="${EJUDGE_FLAGS} ${EJUDGE_ADD_FLAGS}"
+
 unset LANG
 unset LC_ALL
 unset LC_MESSAGES

--- a/scripts/gpc.in
+++ b/scripts/gpc.in
@@ -28,6 +28,8 @@ fi
 
 [ x"${EJUDGE_FLAGS}" = x ] && EJUDGE_FLAGS="-O2"
 
+[ x"${EJUDGE_ADD_FLAGS}" != x ] && EJUDGE_FLAGS="${EJUDGE_FLAGS} ${EJUDGE_ADD_FLAGS}"
+
 unset LANG
 unset LC_ALL
 unset LC_MESSAGES

--- a/scripts/gprolog.in
+++ b/scripts/gprolog.in
@@ -27,6 +27,8 @@ then
     PATH="${GPROLOGDIR}:${PATH}"
 fi
 
+[ x"${EJUDGE_ADD_FLAGS}" != x ] && EJUDGE_FLAGS="${EJUDGE_FLAGS} ${EJUDGE_ADD_FLAGS}"
+
 unset LANG
 unset LC_ALL
 unset LC_MESSAGES

--- a/scripts/javac.in
+++ b/scripts/javac.in
@@ -44,5 +44,8 @@ then
     export PATH
 fi
 
+# EJUDGE_FLAGS is used by ej-javac
+[ x"${EJUDGE_ADD_FLAGS}" != x ] && EJUDGE_FLAGS="${EJUDGE_FLAGS} ${EJUDGE_ADD_FLAGS}"
+
 rm -f *.class
 exec "${libexecdir}/ejudge/lang/ej-javac" "${infile}" "${outfile}" "${JAVACRUN}" "${JAVAVER}" "${MY_JAVA_HOME}"

--- a/scripts/javac7.in
+++ b/scripts/javac7.in
@@ -43,5 +43,8 @@ then
     export PATH
 fi
 
+# EJUDGE_FLAGS is used by ej-javac
+[ x"${EJUDGE_ADD_FLAGS}" != x ] && EJUDGE_FLAGS="${EJUDGE_FLAGS} ${EJUDGE_ADD_FLAGS}"
+
 rm -f *.class
 exec "${libexecdir}/ejudge/lang/ej-javac" "${infile}" "${outfile}" "${JAVACRUN}" "${JAVAVER}" "${MY_JAVA_HOME}"

--- a/scripts/mars.in
+++ b/scripts/mars.in
@@ -20,6 +20,8 @@ then
   exit 1
 fi
 
+[ x"${EJUDGE_ADD_FLAGS}" != x ] && EJUDGE_FLAGS="${EJUDGE_FLAGS} ${EJUDGE_ADD_FLAGS}"
+
 echo "#! ${MARSPATH} ${EJUDGE_FLAGS}" > $2
 echo >> $2
 cat $1 >> $2

--- a/scripts/mcs.in
+++ b/scripts/mcs.in
@@ -31,6 +31,8 @@ fi
 
 [[ "${EJUDGE_FLAGS}" = "" ]] && EJUDGE_FLAGS="-optimize+"
 
+[ x"${EJUDGE_ADD_FLAGS}" != x ] && EJUDGE_FLAGS="${EJUDGE_FLAGS} ${EJUDGE_ADD_FLAGS}"
+
 unset LANG
 unset LC_ALL
 unset LC_MESSAGES

--- a/scripts/mzscheme.in
+++ b/scripts/mzscheme.in
@@ -26,6 +26,8 @@ then
   exit 1
 fi
 
+[ x"${EJUDGE_ADD_FLAGS}" != x ] && EJUDGE_FLAGS="${EJUDGE_FLAGS} ${EJUDGE_ADD_FLAGS}"
+
 echo "#! ${MZSCHEMEPATH} -qr ${EJUDGE_FLAGS}" > $2
 echo >> $2
 cat $1 >> $2

--- a/scripts/nasm-x86.in
+++ b/scripts/nasm-x86.in
@@ -36,6 +36,8 @@ fi
 
 [ x"${EJUDGE_FLAGS}" = x ] && EJUDGE_FLAGS="-Werror"
 
+[ x"${EJUDGE_ADD_FLAGS}" != x ] && EJUDGE_FLAGS="${EJUDGE_FLAGS} ${EJUDGE_ADD_FLAGS}"
+
 unset LANG
 unset LC_ALL
 unset LC_MESSAGES
@@ -44,4 +46,4 @@ unset LANGUAGE
 cp -p "${LANG_CONFIG_DIR}/nasm/io.inc" .
 
 "${NASMRUN}" ${EJUDGE_FLAGS} -DUNIX -f elf "$1" -o "$2.o" || exit $?
-exec "${GCCRUN}" -m32 -o "$2" "$2.o" 
+exec "${GCCRUN}" -m32 -o "$2" "$2.o"

--- a/scripts/node.in
+++ b/scripts/node.in
@@ -25,6 +25,8 @@ then
   exit 1
 fi
 
+[ x"${EJUDGE_ADD_FLAGS}" != x ] && EJUDGE_FLAGS="${EJUDGE_FLAGS} ${EJUDGE_ADD_FLAGS}"
+
 echo "#! ${NODEPATH} ${EJUDGE_FLAGS}" > $2
 echo >> $2
 cat $1 >> $2

--- a/scripts/pasabc-linux.in
+++ b/scripts/pasabc-linux.in
@@ -27,6 +27,8 @@ fi
 
 PATH=`dirname "${PASABC}"`:"${PATH}"
 
+[ x"${EJUDGE_ADD_FLAGS}" != x ] && EJUDGE_FLAGS="${EJUDGE_FLAGS} ${EJUDGE_ADD_FLAGS}"
+
 unset LANG
 unset LC_ALL
 unset LC_MESSAGES

--- a/scripts/perl.in
+++ b/scripts/perl.in
@@ -26,6 +26,8 @@ then
   exit 1
 fi
 
+[ x"${EJUDGE_ADD_FLAGS}" != x ] && EJUDGE_FLAGS="${EJUDGE_FLAGS} ${EJUDGE_ADD_FLAGS}"
+
 echo "#! ${PERLPATH} -W ${EJUDGE_FLAGS}" > $2
 echo >> $2
 cat $1 >> $2

--- a/scripts/pypy.in
+++ b/scripts/pypy.in
@@ -26,6 +26,8 @@ then
   exit 1
 fi
 
+[ x"${EJUDGE_ADD_FLAGS}" != x ] && EJUDGE_FLAGS="${EJUDGE_FLAGS} ${EJUDGE_ADD_FLAGS}"
+
 echo "#! ${PYTHONPATH} -W ignore ${EJUDGE_FLAGS}" > $2
 echo "# coding: latin1" >> $2
 echo >> $2

--- a/scripts/pypy3.in
+++ b/scripts/pypy3.in
@@ -26,6 +26,8 @@ then
   exit 1
 fi
 
+[ x"${EJUDGE_ADD_FLAGS}" != x ] && EJUDGE_FLAGS="${EJUDGE_FLAGS} ${EJUDGE_ADD_FLAGS}"
+
 echo "#! ${PYTHONPATH} -W ignore ${EJUDGE_FLAGS}" > $2
 echo "# coding: latin1" >> $2
 echo >> $2

--- a/scripts/rars.in
+++ b/scripts/rars.in
@@ -20,6 +20,8 @@ then
   exit 1
 fi
 
+[ x"${EJUDGE_ADD_FLAGS}" != x ] && EJUDGE_FLAGS="${EJUDGE_FLAGS} ${EJUDGE_ADD_FLAGS}"
+
 echo "#! ${RARSPATH} ${EJUDGE_FLAGS}" > $2
 echo >> $2
 cat $1 >> $2

--- a/scripts/ruby.in
+++ b/scripts/ruby.in
@@ -26,6 +26,8 @@ then
   exit 1
 fi
 
+[ x"${EJUDGE_ADD_FLAGS}" != x ] && EJUDGE_FLAGS="${EJUDGE_FLAGS} ${EJUDGE_ADD_FLAGS}"
+
 echo "#! ${RUBYPATH} ${EJUDGE_FLAGS}" > $2
 echo >> $2
 cat $1 >> $2

--- a/scripts/rust.in
+++ b/scripts/rust.in
@@ -28,6 +28,8 @@ fi
 
 [ x"${EJUDGE_FLAGS}" = x ] && EJUDGE_FLAGS="-O"
 
+[ x"${EJUDGE_ADD_FLAGS}" != x ] && EJUDGE_FLAGS="${EJUDGE_FLAGS} ${EJUDGE_ADD_FLAGS}"
+
 unset LANG
 unset LC_ALL
 unset LC_MESSAGES

--- a/scripts/swift.in
+++ b/scripts/swift.in
@@ -28,6 +28,8 @@ fi
 
 [ x"${EJUDGE_FLAGS}" = x ] && EJUDGE_FLAGS="-O"
 
+[ x"${EJUDGE_ADD_FLAGS}" != x ] && EJUDGE_FLAGS="${EJUDGE_FLAGS} ${EJUDGE_ADD_FLAGS}"
+
 unset LANG
 unset LC_ALL
 unset LC_MESSAGES

--- a/scripts/vbnc.in
+++ b/scripts/vbnc.in
@@ -30,4 +30,6 @@ then
   PATH="${VBNCDIR}/bin:${PATH}"
 fi
 
+[ x"${EJUDGE_ADD_FLAGS}" != x ] && EJUDGE_FLAGS="${EJUDGE_FLAGS} ${EJUDGE_ADD_FLAGS}"
+
 exec "${VBNCRUN}" ${EJUDGE_FLAGS} "$1" -out:"$2"

--- a/scripts/yabasic.in
+++ b/scripts/yabasic.in
@@ -26,6 +26,8 @@ then
   exit 1
 fi
 
+[ x"${EJUDGE_ADD_FLAGS}" != x ] && EJUDGE_FLAGS="${EJUDGE_FLAGS} ${EJUDGE_ADD_FLAGS}"
+
 echo "#! ${YABASICPATH} ${EJUDGE_FLAGS}" > $2
 echo >> $2
 cat $1 >> $2


### PR DESCRIPTION
С помощью новых переменных в задаче можно добавить флаги компилятора или библиотеки, не перезаписывая стандартный список флагов/библиотек, применяющийся для языка.

Пример файла serve.cfg:
```ini
[language]
id = 2
short_name = "gcc"
long_name = "GNU C 11.3.0"
src_sfx = ".c"
compiler_env = "EJUDGE_FLAGS=-O2 -Wall -Werror -std=gnu11"

...

# Задача с компиляцией решения из нескольких файлов
[problem]
short_name = "test problem"
...
enable_language = "gcc"
# Старый вариант: нужно скопировать все флаги языка, сложно добавить новый флаг для всех задач (его нужно продублировать во всех задачах с переопределёнными флагами)
# lang_compiler_env = "gcc=EJUDGE_FLAGS=-O2 -Wall -Werror -std=gnu11 ${problem.problem_dir}/main.c"
# Новый вариант
lang_compiler_env = "gcc=EJUDGE_ADD_FLAGS=${problem.problem_dir}/main.c"

# Задача с UBSan
[problem]
short_name = "test problem"
...
enable_language = "gcc"
# lang_compiler_env = "gcc=EJUDGE_FLAGS=-O2 -Wall -Werror -std=gnu11 -fsanitize=undefined -fno-sanitize-recover=all"
lang_compiler_env = "gcc=EJUDGE_ADD_FLAGS=-fsanitize=undefined -fno-sanitize-recover=all"
```