### PR TITLE
Import ML as max_rss_size from Polygon

### DIFF
--- a/bin/ej-polygon.c
+++ b/bin/ej-polygon.c
@@ -3488,7 +3488,7 @@ process_polygon_zip(
         prob_cfg->output_file = xstrdup(pi->output_file);
     }
     if (pi->memory_limit > 0) {
-        prob_cfg->max_vm_size = pi->memory_limit;
+        prob_cfg->max_rss_size = pi->memory_limit;
         if (pkt->enable_max_stack_size > 0) {
             prob_cfg->max_stack_size = pi->memory_limit;
         }


### PR DESCRIPTION
This is a new, more correct replacement for the max_vm_size option. Using max_rss_size by default avoids difficulties with runtimes and libraries that allocate large heaps or (ab)use the page table structures as an efficient trie. This is also consistent with Yandex.Contest and most cgroups-based test systems.