### PR TITLE
Empty browser-side cookie should not be equal to any cookie.

### DIFF
--- a/lib/uldb_plugin_xml.c
+++ b/lib/uldb_plugin_xml.c
@@ -902,7 +902,7 @@ get_cookie_func(
     }
   }
 
-  if (c && client_key && c->client_key != client_key) {
+  if (c && c->client_key != client_key) {
     c = NULL;
   }
 


### PR DESCRIPTION
Currently if

* XML userlist database is used,
* browser on client side doesn't have cookie set

cookie comparison returns OK, which is very much incorrect and can lead to potential security issues. Without cookie check, visible in URL session ID becomes usable on a different machine.