### PR TITLE
Fix argument order in some userlist_clnt_delete_cookie calls

### DIFF
--- a/lib/new_server_html.c
+++ b/lib/new_server_html.c
@@ -7970,8 +7970,8 @@ priv_logout(FILE *fout,
     return error_page(fout, phr, 0, NEW_SRV_ERR_USERLIST_SERVER_DOWN);
   userlist_clnt_delete_cookie(ul_conn, phr->user_id,
                               phr->contest_id,
-                              phr->client_key,
-                              phr->session_id);
+                              phr->session_id,
+                              phr->client_key);
   snprintf(urlbuf, sizeof(urlbuf),
            "%s?contest_id=%d&locale_id=%d&role=%d",
            phr->self_url, phr->contest_id, phr->locale_id, phr->role);

--- a/lib/super_html_4.c
+++ b/lib/super_html_4.c
@@ -258,8 +258,8 @@ cmd_logout(
   if (phr->userlist_clnt) {
     userlist_clnt_delete_cookie(phr->userlist_clnt, phr->user_id,
                                 0,
-                                phr->client_key,
-                                phr->session_id);
+                                phr->session_id,
+                                phr->client_key);
   }
   // FIXME: release other session-related resources
   phr->session_id = 0;


### PR DESCRIPTION
SID and cookie have the same type, and in some calls their order was mixed up. Fix it.