### PR TITLE
Fix problem_dir check path resolution

### DIFF
--- a/lib/prepare_out.c
+++ b/lib/prepare_out.c
@@ -3205,6 +3205,8 @@ prob_instr(
   }
 
   tmp_prob = prepare_copy_problem(prob);
+  /* resolve inherited problem_dir before using it */
+  prepare_set_prob_value(CNTSPROB_problem_dir, tmp_prob, abstr, global);
   mkpath(conf_path, root_dir, conf_dir, "conf");
 
   if (global->advanced_layout > 0) {


### PR DESCRIPTION
При использовании problem_dir, начинающегося с `/` в абстрактной задаче и problem_dir, не начинающейся с `/` или `.` в конретной задаче путь к папке задачи является конкатенацией путей.
Однако на этапе проверки после commit'а настроек, используются неправильные пути:
![telegram-cloud-photo-size-2-5321406425127320548-w](https://github.com/user-attachments/assets/b4ce6f7e-9984-49f3-9123-db746b26031e)
Вместо problem_dir абстрактной задачи используется стандартный problems внутри контеста.

```ini
[problem]
abstract
short_name = "Generic"
problem_dir = "/home/judges/problems"
...

[problem]
id = 20
super = "Generic"
short_name = "B"
problem_dir = "some/problems/dir"
```

Данный патч исправляет эту проверку.