### PR TITLE
Fix filter expression nerrs

### DIFF
--- a/lib/filter_expr.y
+++ b/lib/filter_expr.y
@@ -1267,6 +1267,8 @@ filter_expr_init_parser(struct filter_tree_mem *mem,
                         void (*errfunc)(void *, unsigned char const *, ...),
                         void *user_data)
 {
+  filter_expr_nerrs = 0;
+  filter_expr_lval = NULL;
   filter_expr_tree_mem = mem;
   filter_expr_parse_err = errfunc;
   filter_expr_user_data = user_data;


### PR DESCRIPTION
После одного некорректного запроса к API ejudge get-list-runs-json последующие верные запросы падают с ошибкой из-за того, что filter_expr_nerrs не сбрасывается перед новым парсингом filter_expr, я получаю старую ошибку. Поэтому добавил сброс.