### PR TITLE
Added OpenDocument MIME type support

### DIFF
--- a/include/ejudge/mime_type.h
+++ b/include/ejudge/mime_type.h
@@ -54,6 +54,15 @@ enum
   MIME_TYPE_OFFICE_PPTX,        // application/vnd.openxmlformats-officedocument.presentationml.presentation
   MIME_TYPE_OFFICE_XLSX,        // application/vnd.openxmlformats-officedocument.presentationml.presentation
   MIME_TYPE_OFFICE_DOCX,        // application/vnd.openxmlformats-officedocument.wordprocessingml.document
+  MIME_TYPE_OFFICE_ODT,         // application/vnd.oasis.opendocument.text
+  MIME_TYPE_OFFICE_ODS,         // application/vnd.oasis.opendocument.spreadsheet
+  MIME_TYPE_OFFICE_ODP,         // application/vnd.oasis.opendocument.presentation
+  MIME_TYPE_OFFICE_ODG,         // application/vnd.oasis.opendocument.graphics
+  MIME_TYPE_OFFICE_ODC,         // application/vnd.oasis.opendocument.chart
+  MIME_TYPE_OFFICE_ODF,         // application/vnd.oasis.opendocument.formula
+  MIME_TYPE_OFFICE_ODI,         // application/vnd.oasis.opendocument.image
+  MIME_TYPE_OFFICE_ODM,         // application/vnd.oasis.opendocument.text-master
+  MIME_TYPE_OFFICE_ODB,         // application/vnd.oasis.opendocument.base
 
   MIME_TYPE_LAST,
 };

--- a/lib/mime_type.c
+++ b/lib/mime_type.c
@@ -115,10 +115,73 @@ static const struct mime_type_info mime_types[MIME_TYPE_LAST] =
     ".docx",
     "Microsoft Word 2007+",
   },
+  [MIME_TYPE_OFFICE_ODT] =
+  {
+    "application/vnd.oasis.opendocument.text",
+    ".odt",
+    "OpenDocument Text",
+  },
+  [MIME_TYPE_OFFICE_ODS] =
+  {
+    "application/vnd.oasis.opendocument.spreadsheet",
+    ".ods",
+    "OpenDocument Spreadsheet",
+  },
+  [MIME_TYPE_OFFICE_ODP] =
+  {
+    "application/vnd.oasis.opendocument.presentation",
+    ".odp",
+    "OpenDocument Presentation",
+  },
+  [MIME_TYPE_OFFICE_ODG] =
+  {
+    "application/vnd.oasis.opendocument.graphics",
+    ".odg",
+    "OpenDocument Graphics",
+  },
+  [MIME_TYPE_OFFICE_ODC] =
+  {
+    "application/vnd.oasis.opendocument.chart",
+    ".odc",
+    "OpenDocument Chart",
+  },
+  [MIME_TYPE_OFFICE_ODF] =
+  {
+    "application/vnd.oasis.opendocument.formula",
+    ".odf",
+    "OpenDocument Formula",
+  },
+  [MIME_TYPE_OFFICE_ODI] =
+  {
+    "application/vnd.oasis.opendocument.image",
+    ".odi",
+    "OpenDocument Image",
+  },
+  [MIME_TYPE_OFFICE_ODM] =
+  {
+    "application/vnd.oasis.opendocument.text-master",
+    ".odm",
+    "OpenDocument Master Document",
+  },
+  [MIME_TYPE_OFFICE_ODB] =
+  {
+    "application/vnd.oasis.opendocument.base",
+    ".odb",
+    "OpenDocument Database",
+  },
 };
 
 static const int mime_check_order[] =
 {
+  MIME_TYPE_OFFICE_ODT,
+  MIME_TYPE_OFFICE_ODS,
+  MIME_TYPE_OFFICE_ODP,
+  MIME_TYPE_OFFICE_ODG,
+  MIME_TYPE_OFFICE_ODC,
+  MIME_TYPE_OFFICE_ODF,
+  MIME_TYPE_OFFICE_ODI,
+  MIME_TYPE_OFFICE_ODM,
+  MIME_TYPE_OFFICE_ODB,
   MIME_TYPE_OFFICE_PPTX,
   MIME_TYPE_OFFICE_XLSX,
   MIME_TYPE_OFFICE_DOCX,


### PR DESCRIPTION
Add MIME types for OpenDocument (Libre office) formats:

- .odt — text
- .ods — spreadsheet
- .odp — presentation
- .odg — graphics
- .odc — chart
- .odf — formula
- .odi — image
- .odm — text master
- .odb — database