### PR TITLE
Fix run iteration in daily statistics generation

### DIFF
--- a/lib/master_html.c
+++ b/lib/master_html.c
@@ -869,7 +869,7 @@ generate_daily_statistics(
   XALLOCAZ(p_total, p_tot);
   XALLOCAZ(p_ok, p_tot);
 
-  for (i = r_beg, rcur = runs; i < r_tot; i++, rcur++) {
+  for (i = r_beg, rcur = runs + r_beg; i < r_tot; i++, rcur++) {
     if (rcur->time >= to_time) break;
     if (rcur->time < from_time) {
       if (rcur->status == RUN_EMPTY) continue;


### PR DESCRIPTION
В функции generate_daily_statistics цикл, перебирающий решения содержит ошибку
  for (i = r_beg, rcur = runs; i < r_tot; i++, rcur++) {
  
  Если в списке сабмитов первые сабмиты были удалены (они отсутствуют), то цикл по этим сабмитам, начинающийся с указателя runs, разыменовывает некорректный указатель и ej-contests падает на следующей строке if (rcur->time >= to_time) break;
  
  Для пропуска удалённых сабмитов цикл нужно начинать со значения runs + r_beg

